### PR TITLE
Drop superfluous CHECK_HEADER_ADD_INCLUDE() call

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -4,10 +4,6 @@
 ARG_ENABLE("timezonedb", "timezonedb support", "no");
 
 if (PHP_TIMEZONEDB != "no") {
-	if (CHECK_HEADER_ADD_INCLUDE("timelib_config.h", "CFLAGS_TIMEZONEDB", "ext/date/lib")) {
-		EXTENSION("timezonedb", "timezonedb.c");
-		AC_DEFINE("HAVE_TIMEZONEDB", 1, "timezonedb support");
-	} else {
-		WARNING("timezonedb not enabled; headers not found");
-	}
+	EXTENSION("timezonedb", "timezonedb.c");
+	AC_DEFINE("HAVE_TIMEZONEDB", 1, "timezonedb support");
 }


### PR DESCRIPTION
The include directories are already properly set up for in-tree as well as phpize builds on Windows.  Checking that timelib_config.h exists would be nice, but required to add the path for phpize builds, and since this is not done for other operating systems, it appears to be overkill for Windows.