### PR TITLE
Fixes #16

### DIFF
--- a/php_timezonedb.h
+++ b/php_timezonedb.h
@@ -29,6 +29,7 @@ extern zend_module_entry timezonedb_module_entry;
 #define PHP_TIMEZONEDB_VERSION "2026.1"
 
 PHP_MINIT_FUNCTION(timezonedb);
+PHP_MSHUTDOWN_FUNCTION(timezonedb);
 PHP_MINFO_FUNCTION(timezonedb);
 
 #endif	/* TIMEZONEDB_H */

--- a/timezonedb.c
+++ b/timezonedb.c
@@ -76,7 +76,7 @@ zend_module_entry timezonedb_module_entry = {
 	"timezonedb",
 	timezonedb_functions,
 	PHP_MINIT(timezonedb),
-	NULL,
+	PHP_MSHUTDOWN(timezonedb),
 	NULL,
 	NULL,
 	PHP_MINFO(timezonedb),
@@ -102,6 +102,7 @@ PHP_MINIT_FUNCTION(timezonedb)
  */
 PHP_MSHUTDOWN_FUNCTION(timezonedb)
 {
+	php_date_set_tzdb((timelib_tzdb *) timelib_builtin_db());
 	return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
The `timezonedb` extension calls `php_date_set_tzdb(&timezonedb_external)` during MINIT, pointing the date extension's global tzdb pointer at data inside the timezonedb shared object. When Apache restarts, the timezonedb SO gets unloaded but the date extension still holds the now-stale pointer. On re-initialization, the date extension starts before timezonedb (due to the dependency order) and tries to validate the "UTC" timezone against the invalid pointer, causing a segfault in `seek_to_tz_position`.

The fix registers the existing `PHP_MSHUTDOWN_FUNCTION` in the module entry and resets the tzdb pointer back to PHP's builtin timezone database before the SO is unloaded.